### PR TITLE
Use TTF_RenderText_Blended for smoother text

### DIFF
--- a/ZSharp/graphics.h
+++ b/ZSharp/graphics.h
@@ -554,7 +554,7 @@ public:
 	{
 		SDL_Color color = { r, g, b };
 
-		SDL_Surface* surface = TTF_RenderText_Solid(font, content.c_str(), color);
+		SDL_Surface* surface = TTF_RenderText_Blended(font, content.c_str(), color);
 
 		SDL_DestroyTexture(texture);
 		texture = SDL_CreateTextureFromSurface(gRenderer, surface);


### PR DESCRIPTION
This PR makes the font loader use TTF_RenderText_Blended instead of TTF_RenderText_Solid so that text looks antialiased and epically cool xd